### PR TITLE
Replace spaces in list name when defining schema modules

### DIFF
--- a/lib/ecto_gss/schema.ex
+++ b/lib/ecto_gss/schema.ex
@@ -23,8 +23,10 @@ defmodule EctoGSS.Schema do
           def gss_schema_type, do: true
         end
 
+      safe_list_name = String.replace(list, " ", "")
+
       Module.create(
-        Module.concat(EctoGSS.Schema, "#{list}.#{gss_column}"),
+        Module.concat(EctoGSS.Schema, "#{safe_list_name}.#{gss_column}"),
         code,
         Macro.Env.location(__ENV__)
       )

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -1,0 +1,23 @@
+defmodule EctoGSS.SchemaTest do
+  use ExUnit.Case, async: true
+
+  defmodule Account do
+    use EctoGSS.Schema, {
+      :model,
+      columns: ["A", "Y"],
+      list: "All Accounts",
+      spreadsheet: "1h85keViqbRzgTN245gEw5s9roxpaUtT7i-mNXQtT8qQ"
+    }
+
+    use Ecto.Schema
+
+    schema "accounts" do
+      field(:nickname, EctoGSS.Schema.AllAccounts.A)
+      field(:email, EctoGSS.Schema.AllAccounts.Y)
+    end
+  end
+
+  test "list names with spaces" do
+    assert match?({:module, _}, Code.ensure_compiled(EctoGSS.Schema.AllAccounts.A))
+  end
+end


### PR DESCRIPTION
I'm working with a spreadsheet that I couldn't control the naming of, and unfortunately the user had included spaces in the sheet list name.

When the list name includes spaces, I couldn't get the schema field names to find the correct module for the column (even if I use `:"EctoGSS.Schema.List Name.A` which I felt like should have worked).

Added a test to make sure that it all works, although it will blow up before this because it would fail to compile without my change anyway.